### PR TITLE
Add Bun setup to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - name: Cache Bun
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.bun
+            node_modules
+          key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+      - name: Install dependencies
+        run: bun install
+      - name: Build
+        run: bun run build
+      - name: Test
+        run: bun test

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
  
 # Dependencies
 node_modules/
+node-compile-cache/
 
 # Environment files
 .env


### PR DESCRIPTION
## Summary
- add GitHub workflow for Bun based CI
- ignore node-compile-cache

## Testing
- `bun --version`
- `bun install`
- `bun run build`
- `bun test` *(fails: MCP error -1: Connection closed)*

------
https://chatgpt.com/codex/tasks/task_e_68488cf22eb88322ae4cbb316cdc52df