### PR TITLE
Add bunfig with bundle and test settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ node_modules/
 
 .vscode/
 
+node-compile-cache/

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,6 @@
+[bundle]
+entryPoints = ["index.ts"]
+outdir = "dist"
+
+[test]
+root = "test"


### PR DESCRIPTION
## Summary
- add `bunfig.toml` describing bundle entry point and test root
- ignore `node-compile-cache/`

## Testing
- `bun test` *(fails: ENOENT errors)*
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68488ce17f08832282c838b566cd6404