### PR TITLE
Replace Zod safeParse with TypeBox validation

### DIFF
--- a/src/handlers/file-handlers.ts
+++ b/src/handlers/file-handlers.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import { Permissions } from '../config/permissions.js';
 import { validatePath } from '../utils/path-utils.js';
+import { parseArgs } from '../utils/schema-utils.js';
 import { getFileStats, applyFileEdits } from '../utils/file-utils.js';
 import {
   ReadFileArgsSchema,
@@ -10,7 +11,15 @@ import {
   GetFileInfoArgsSchema,
   MoveFileArgsSchema,
   DeleteFileArgsSchema,
-  RenameFileArgsSchema
+  RenameFileArgsSchema,
+  type ReadFileArgs,
+  type ReadMultipleFilesArgs,
+  type WriteFileArgs,
+  type EditFileArgs,
+  type GetFileInfoArgs,
+  type MoveFileArgs,
+  type DeleteFileArgs,
+  type RenameFileArgs
 } from '../schemas/file-operations.js';
 import path from 'path';
 
@@ -20,11 +29,7 @@ export async function handleReadFile(
   symlinksMap: Map<string, string>,
   noFollowSymlinks: boolean
 ) {
-  const parsed = ReadFileArgsSchema.safeParse(args);
-  if (!parsed.success) {
-    throw new Error(`Invalid arguments for read_file: ${parsed.error}`);
-  }
-  const { path: filePath, maxBytes } = parsed.data;
+  const { path: filePath, maxBytes } = parseArgs(ReadFileArgsSchema, args, 'read_file');
   const validPath = await validatePath(filePath, allowedDirectories, symlinksMap, noFollowSymlinks);
   
   // Check file size before reading
@@ -46,11 +51,7 @@ export async function handleReadMultipleFiles(
   symlinksMap: Map<string, string>,
   noFollowSymlinks: boolean
 ) {
-  const parsed = ReadMultipleFilesArgsSchema.safeParse(args);
-  if (!parsed.success) {
-    throw new Error(`Invalid arguments for read_multiple_files: ${parsed.error}`);
-  }
-  const { paths, maxBytesPerFile } = parsed.data;
+  const { paths, maxBytesPerFile } = parseArgs(ReadMultipleFilesArgsSchema, args, 'read_multiple_files');
   const effectiveMaxBytes = maxBytesPerFile ?? (10 * 1024); // Default 10KB per file
   
   const results = await Promise.all(
@@ -84,13 +85,10 @@ export async function handleCreateFile(
   symlinksMap: Map<string, string>,
   noFollowSymlinks: boolean
 ) {
-  const parsed = WriteFileArgsSchema.safeParse(args);
-  if (!parsed.success) {
-    throw new Error(`Invalid arguments for create_file: ${parsed.error}`);
-  }
+  const data = parseArgs(WriteFileArgsSchema, args, 'create_file');
   
   const validPath = await validatePath(
-    parsed.data.path,
+    data.path,
     allowedDirectories,
     symlinksMap,
     noFollowSymlinks,
@@ -101,7 +99,7 @@ export async function handleCreateFile(
   try {
     await fs.access(validPath);
     // If access succeeds, file exists
-    throw new Error(`File already exists: ${parsed.data.path}`);
+    throw new Error(`File already exists: ${data.path}`);
   } catch (error) {
      const msg = error instanceof Error ? error.message : String(error);
      if (!msg.includes('ENOENT')) { // Rethrow if it's not a "file not found" error
@@ -116,9 +114,9 @@ export async function handleCreateFile(
      const parentDir = path.dirname(validPath);
      await fs.mkdir(parentDir, { recursive: true });
 
-     await fs.writeFile(validPath, parsed.data.content, "utf-8");
+     await fs.writeFile(validPath, data.content, "utf-8");
      return {
-       content: [{ type: "text", text: `Successfully created ${parsed.data.path}` }],
+       content: [{ type: "text", text: `Successfully created ${data.path}` }],
      };
   }
 }
@@ -130,12 +128,9 @@ export async function handleModifyFile(
   symlinksMap: Map<string, string>,
   noFollowSymlinks: boolean
 ) {
-  const parsed = WriteFileArgsSchema.safeParse(args);
-  if (!parsed.success) {
-    throw new Error(`Invalid arguments for modify_file: ${parsed.error}`);
-  }
-  
-  const validPath = await validatePath(parsed.data.path, allowedDirectories, symlinksMap, noFollowSymlinks);
+  const data = parseArgs(WriteFileArgsSchema, args, 'modify_file');
+
+  const validPath = await validatePath(data.path, allowedDirectories, symlinksMap, noFollowSymlinks);
   
   // Check if file exists
   try {
@@ -145,9 +140,9 @@ export async function handleModifyFile(
       throw new Error('Cannot modify file: edit permission not granted (requires --allow-edit)');
     }
     
-    await fs.writeFile(validPath, parsed.data.content, "utf-8");
+    await fs.writeFile(validPath, data.content, "utf-8");
     return {
-      content: [{ type: "text", text: `Successfully modified ${parsed.data.path}` }],
+      content: [{ type: "text", text: `Successfully modified ${data.path}` }],
     };
   } catch (error) {
     throw new Error('Cannot modify file: file does not exist');
@@ -161,17 +156,14 @@ export async function handleEditFile(
   symlinksMap: Map<string, string>,
   noFollowSymlinks: boolean
 ) {
-  const parsed = EditFileArgsSchema.safeParse(args);
-  if (!parsed.success) {
-    throw new Error(`Invalid arguments for edit_file: ${parsed.error}`);
-  }
+  const parsed = parseArgs(EditFileArgsSchema, args, 'edit_file');
   
   // Enforce permission checks
   if (!permissions.edit && !permissions.fullAccess) {
     throw new Error('Cannot edit file: edit permission not granted (requires --allow-edit)');
   }
   
-  const { path: filePath, edits, dryRun, maxBytes } = parsed.data;
+  const { path: filePath, edits, dryRun, maxBytes } = parsed;
   const validPath = await validatePath(filePath, allowedDirectories, symlinksMap, noFollowSymlinks);
   
   // Check file size before attempting to read/edit
@@ -193,11 +185,8 @@ export async function handleGetFileInfo(
   symlinksMap: Map<string, string>,
   noFollowSymlinks: boolean
 ) {
-  const parsed = GetFileInfoArgsSchema.safeParse(args);
-  if (!parsed.success) {
-    throw new Error(`Invalid arguments for get_file_info: ${parsed.error}`);
-  }
-  const validPath = await validatePath(parsed.data.path, allowedDirectories, symlinksMap, noFollowSymlinks);
+  const parsed = parseArgs(GetFileInfoArgsSchema, args, 'get_file_info');
+  const validPath = await validatePath(parsed.path, allowedDirectories, symlinksMap, noFollowSymlinks);
   const info = await getFileStats(validPath);
   return {
     content: [{ type: "text", text: Object.entries(info)
@@ -213,20 +202,17 @@ export async function handleMoveFile(
   symlinksMap: Map<string, string>,
   noFollowSymlinks: boolean
 ) {
-  const parsed = MoveFileArgsSchema.safeParse(args);
-  if (!parsed.success) {
-    throw new Error(`Invalid arguments for move_file: ${parsed.error}`);
-  }
+  const parsed = parseArgs(MoveFileArgsSchema, args, 'move_file');
   
   // Enforce permission checks
   if (!permissions.move && !permissions.fullAccess) {
     throw new Error('Cannot move file: move permission not granted (requires --allow-move)');
   }
   
-  const validSourcePath = await validatePath(parsed.data.source, allowedDirectories, symlinksMap, noFollowSymlinks); // No option here, source must exist
+  const validSourcePath = await validatePath(parsed.source, allowedDirectories, symlinksMap, noFollowSymlinks); // No option here, source must exist
 
   const validDestPath = await validatePath(
-    parsed.data.destination,
+    parsed.destination,
     allowedDirectories,
     symlinksMap,
     noFollowSymlinks,
@@ -237,12 +223,12 @@ export async function handleMoveFile(
   try {
       await fs.access(destParentDir);
   } catch {
-      throw new Error(`Destination parent directory does not exist: ${path.dirname(parsed.data.destination)}`);
+      throw new Error(`Destination parent directory does not exist: ${path.dirname(parsed.destination)}`);
   }
 
   await fs.rename(validSourcePath, validDestPath);
   return {
-    content: [{ type: "text", text: `Successfully moved ${parsed.data.source} to ${parsed.data.destination}` }],
+    content: [{ type: "text", text: `Successfully moved ${parsed.source} to ${parsed.destination}` }],
   };
 }
 
@@ -253,24 +239,21 @@ export async function handleDeleteFile(
   symlinksMap: Map<string, string>,
   noFollowSymlinks: boolean
 ) {
-  const parsed = DeleteFileArgsSchema.safeParse(args);
-  if (!parsed.success) {
-    throw new Error(`Invalid arguments for delete_file: ${parsed.error}`);
-  }
+  const parsed = parseArgs(DeleteFileArgsSchema, args, 'delete_file');
   
   // Enforce permission checks
   if (!permissions.delete && !permissions.fullAccess) {
     throw new Error('Cannot delete file: delete permission not granted (requires --allow-delete)');
   }
   
-  const validPath = await validatePath(parsed.data.path, allowedDirectories, symlinksMap, noFollowSymlinks);
+  const validPath = await validatePath(parsed.path, allowedDirectories, symlinksMap, noFollowSymlinks);
   
   try {
     // Check if file exists
     await fs.access(validPath);
     await fs.unlink(validPath);
     return {
-      content: [{ type: "text", text: `Successfully deleted ${parsed.data.path}` }],
+      content: [{ type: "text", text: `Successfully deleted ${parsed.path}` }],
     };
   } catch (error) {
     throw new Error(`Failed to delete file: ${error instanceof Error ? error.message : String(error)}`);
@@ -284,23 +267,20 @@ export async function handleRenameFile(
   symlinksMap: Map<string, string>,
   noFollowSymlinks: boolean
 ) {
-  const parsed = RenameFileArgsSchema.safeParse(args);
-  if (!parsed.success) {
-    throw new Error(`Invalid arguments for rename_file: ${parsed.error}`);
-  }
+  const parsed = parseArgs(RenameFileArgsSchema, args, 'rename_file');
   
   // Enforce permission checks - rename requires the rename permission
   if (!permissions.rename && !permissions.fullAccess) {
     throw new Error('Cannot rename file: rename permission not granted (requires --allow-rename)');
   }
   
-  const validSourcePath = await validatePath(parsed.data.path, allowedDirectories, symlinksMap, noFollowSymlinks);
+  const validSourcePath = await validatePath(parsed.path, allowedDirectories, symlinksMap, noFollowSymlinks);
   
   // Get the directory from the source path
   const directory = path.dirname(validSourcePath);
   
   // Create the destination path using the same directory and the new name
-  const destinationPath = path.join(directory, parsed.data.newName);
+  const destinationPath = path.join(directory, parsed.newName);
   
   // Validate the destination path
   const validDestPath = await validatePath(destinationPath, allowedDirectories, symlinksMap, noFollowSymlinks);
@@ -308,7 +288,7 @@ export async function handleRenameFile(
   // Check if destination already exists
   try {
     await fs.access(validDestPath);
-    throw new Error(`Cannot rename file: a file with name "${parsed.data.newName}" already exists in the directory`);
+    throw new Error(`Cannot rename file: a file with name "${parsed.newName}" already exists in the directory`);
   } catch (error) {
     // We want this error - it means the destination doesn't exist yet
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
@@ -318,8 +298,8 @@ export async function handleRenameFile(
   
   // Perform the rename operation
   await fs.rename(validSourcePath, validDestPath);
-  
+
   return {
-    content: [{ type: "text", text: `Successfully renamed ${parsed.data.path} to ${parsed.data.newName}` }],
+    content: [{ type: "text", text: `Successfully renamed ${parsed.path} to ${parsed.newName}` }],
   };
-} 
+}

--- a/src/handlers/utility-handlers.ts
+++ b/src/handlers/utility-handlers.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { XMLParser } from 'fast-xml-parser';
 import { Permissions } from '../config/permissions.js';
 import { validatePath } from '../utils/path-utils.js';
+import { parseArgs } from '../utils/schema-utils.js';
 import { searchFiles, findFilesByExtension, regexSearchContent } from '../utils/file-utils.js';
 import {
   GetPermissionsArgsSchema,
@@ -10,7 +11,13 @@ import {
   FindFilesByExtensionArgsSchema,
   XmlToJsonArgsSchema,
   XmlToJsonStringArgsSchema,
-  RegexSearchContentArgsSchema // Added import
+  RegexSearchContentArgsSchema, // Added import
+  type GetPermissionsArgs,
+  type SearchFilesArgs,
+  type FindFilesByExtensionArgs,
+  type XmlToJsonArgs,
+  type XmlToJsonStringArgs,
+  type RegexSearchContentArgs
 } from '../schemas/utility-operations.js';
 
 export function handleGetPermissions(
@@ -20,10 +27,7 @@ export function handleGetPermissions(
   noFollowSymlinks: boolean,
   allowedDirectories: string[]
 ) {
-  const parsed = GetPermissionsArgsSchema.safeParse(args);
-  if (!parsed.success) {
-    throw new Error(`Invalid arguments for get_permissions: ${parsed.error}`);
-  }
+  parseArgs(GetPermissionsArgsSchema, args, 'get_permissions');
 
   return {
     content: [{
@@ -52,11 +56,8 @@ export async function handleSearchFiles(
   symlinksMap: Map<string, string>,
   noFollowSymlinks: boolean
 ) {
-  const parsed = SearchFilesArgsSchema.safeParse(args);
-  if (!parsed.success) {
-    throw new Error(`Invalid arguments for search_files: ${parsed.error}`);
-  }
-  const { path: startPath, pattern, excludePatterns, maxDepth, maxResults } = parsed.data;
+  const parsed = parseArgs(SearchFilesArgsSchema, args, 'search_files');
+  const { path: startPath, pattern, excludePatterns, maxDepth, maxResults } = parsed;
   const validPath = await validatePath(startPath, allowedDirectories, symlinksMap, noFollowSymlinks);
   // TODO: Update searchFiles in file-utils.ts to accept and use maxDepth and maxResults
   const results = await searchFiles(validPath, pattern, excludePatterns, maxDepth, maxResults);
@@ -71,11 +72,8 @@ export async function handleFindFilesByExtension(
   symlinksMap: Map<string, string>,
   noFollowSymlinks: boolean
 ) {
-  const parsed = FindFilesByExtensionArgsSchema.safeParse(args);
-  if (!parsed.success) {
-    throw new Error(`Invalid arguments for find_files_by_extension: ${parsed.error}`);
-  }
-  const { path: startPath, extension, excludePatterns, maxDepth, maxResults } = parsed.data;
+  const parsed = parseArgs(FindFilesByExtensionArgsSchema, args, 'find_files_by_extension');
+  const { path: startPath, extension, excludePatterns, maxDepth, maxResults } = parsed;
   const validPath = await validatePath(startPath, allowedDirectories, symlinksMap, noFollowSymlinks);
   // TODO: Update findFilesByExtension in file-utils.ts to accept and use maxDepth and maxResults
   const results = await findFilesByExtension(
@@ -97,12 +95,9 @@ export async function handleXmlToJson(
   symlinksMap: Map<string, string>,
   noFollowSymlinks: boolean
 ) {
-  const parsed = XmlToJsonArgsSchema.safeParse(args);
-  if (!parsed.success) {
-    throw new Error(`Invalid arguments for xml_to_json: ${parsed.error}`);
-  }
-  
-  const { xmlPath, jsonPath, maxBytes, options } = parsed.data;
+  const parsed = parseArgs(XmlToJsonArgsSchema, args, 'xml_to_json');
+
+  const { xmlPath, jsonPath, maxBytes, options } = parsed;
   const validXmlPath = await validatePath(xmlPath, allowedDirectories, symlinksMap, noFollowSymlinks); // Source must exist
 
   const validJsonPath = await validatePath(
@@ -182,12 +177,9 @@ export async function handleXmlToJsonString(
   symlinksMap: Map<string, string>,
   noFollowSymlinks: boolean
 ) {
-  const parsed = XmlToJsonStringArgsSchema.safeParse(args);
-  if (!parsed.success) {
-    throw new Error(`Invalid arguments for xml_to_json_string: ${parsed.error}`);
-  }
-  
-  const { xmlPath, maxBytes, options } = parsed.data;
+  const parsed = parseArgs(XmlToJsonStringArgsSchema, args, 'xml_to_json_string');
+
+  const { xmlPath, maxBytes, options } = parsed;
   const validXmlPath = await validatePath(xmlPath, allowedDirectories, symlinksMap, noFollowSymlinks);
   
   try {
@@ -241,10 +233,7 @@ export async function handleRegexSearchContent(
   symlinksMap: Map<string, string>,
   noFollowSymlinks: boolean
 ) {
-  const parsed = RegexSearchContentArgsSchema.safeParse(args);
-  if (!parsed.success) {
-    throw new Error(`Invalid arguments for regex_search_content: ${parsed.error}`);
-  }
+  const parsed = parseArgs(RegexSearchContentArgsSchema, args, 'regex_search_content');
   const {
     path: startPath,
     regex,
@@ -252,7 +241,7 @@ export async function handleRegexSearchContent(
     maxDepth,
     maxFileSize,
     maxResults
-  } = parsed.data;
+  } = parsed;
 
   const validPath = await validatePath(startPath, allowedDirectories, symlinksMap, noFollowSymlinks);
 

--- a/src/utils/schema-utils.ts
+++ b/src/utils/schema-utils.ts
@@ -1,0 +1,14 @@
+import { Value } from '@sinclair/typebox/value';
+import type { Static, TSchema } from '@sinclair/typebox';
+
+export function parseArgs<T extends TSchema>(schema: T, args: unknown, context: string): Static<T> {
+  try {
+    // Use only the Assert step to mimic Zod's strict validation
+    return Value.Parse(['Assert'], schema, args);
+  } catch {
+    const errors = [...Value.Errors(schema, args)]
+      .map(e => `${e.path}: ${e.message}`)
+      .join('; ');
+    throw new Error(`Invalid arguments for ${context}: ${errors}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add parseArgs helper that validates with TypeBox's `Value.Parse`
- migrate handlers to use `parseArgs`
- remove Zod

## Testing
- `npm run build`
- `npm test` *(fails: ENOENT errors during test setup)*

------
https://chatgpt.com/codex/tasks/task_e_68489b52ae4c8322832e85a62154d506