### PR TITLE
Update Dockerfile for Bun lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM oven/bun AS builder
 WORKDIR /app
 
 COPY src/filesystem /app
+COPY package.json /app/package.json
+COPY bun.lock /app/bun.lock
 COPY tsconfig.json /tsconfig.json
 
 RUN --mount=type=cache,target=/root/.bun bun install
@@ -16,10 +18,10 @@ WORKDIR /app
 
 COPY --from=builder /app/dist /app/dist
 COPY --from=builder /app/package.json /app/package.json
-COPY --from=builder /app/package-lock.json /app/package-lock.json
+COPY --from=builder /app/bun.lock /app/bun.lock
 
 ENV NODE_ENV=production
 
-RUN bun install --production
+RUN bun install --production --frozen-lockfile
 
 ENTRYPOINT ["bun", "/app/dist/index.js"]


### PR DESCRIPTION
## Summary
- copy `bun.lock` into build and runtime stages
- drop old package-lock.json reference
- freeze lockfile on production install

## Testing
- `bun test` *(fails: ENOENT /Users/mateicanavra/Documents/.nosync/DEV/test)*

------
https://chatgpt.com/codex/tasks/task_e_6848a2a11f808322b8896ca18f982642