### PR TITLE
Clean up lingering Zod references

### DIFF
--- a/src/schemas/file-operations.ts
+++ b/src/schemas/file-operations.ts
@@ -70,13 +70,3 @@ export const RenameFileArgsSchema = Type.Object({
 });
 export type RenameFileArgs = Static<typeof RenameFileArgsSchema>;
 
-// Schemas previously defined in index.ts but related to other files (kept here for reference during refactor, but should be removed from index.ts)
-// export const GetPermissionsArgsSchema = z.object({}); // Moved to utility-operations.ts
-// export const CreateDirectoryArgsSchema = z.object({ path: z.string() }); // Moved to directory-operations.ts
-// export const ListDirectoryArgsSchema = z.object({ path: z.string() }); // Moved to directory-operations.ts
-// export const DirectoryTreeArgsSchema = z.object({ path: z.string() }); // Moved to directory-operations.ts
-// export const SearchFilesArgsSchema = z.object({ path: z.string(), pattern: z.string(), excludePatterns: z.array(z.string()).optional().default([]) }); // Moved to utility-operations.ts
-// export const FindFilesByExtensionArgsSchema = z.object({ path: z.string(), extension: z.string().describe('File extension...'), excludePatterns: z.array(z.string()).optional().default([]) }); // Moved to utility-operations.ts
-// export const DeleteDirectoryArgsSchema = z.object({ path: z.string(), recursive: z.boolean().default(false).describe('Whether to recursively delete...') }); // Moved to directory-operations.ts
-// export const XmlToJsonArgsSchema = z.object({ /* ... */ }); // Moved to utility-operations.ts
-// export const XmlToJsonStringArgsSchema = z.object({ /* ... */ }); // Moved to utility-operations.ts

--- a/src/utils/schema-utils.ts
+++ b/src/utils/schema-utils.ts
@@ -3,7 +3,7 @@ import type { Static, TSchema } from '@sinclair/typebox';
 
 export function parseArgs<T extends TSchema>(schema: T, args: unknown, context: string): Static<T> {
   try {
-    // Use only the Assert step to mimic Zod's strict validation
+    // Use only the Assert step to ensure strict validation
     return Value.Parse(['Assert'], schema, args);
   } catch {
     const errors = [...Value.Errors(schema, args)]


### PR DESCRIPTION
## Summary
- drop old Zod comment from schema utils
- delete Zod references from file schemas

## Testing
- `bun install --force`
- `bun test` *(fails: MCP error -32000)*

------
https://chatgpt.com/codex/tasks/task_e_6848a84904888322a7b23d7b2d5c695b