### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Node.js server implementing Model Context Protocol (MCP) for filesystem operations with comprehensive permission controls and enhanced functionality.
 
+<a href="https://glama.ai/mcp/servers/@rawr-ai/mcp-filesystem">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@rawr-ai/mcp-filesystem/badge" alt="Filesystem Server MCP server" />
+</a>
+
 ## Features
 
 - Granular permission controls (read-only, full access, or specific operation permissions)


### PR DESCRIPTION
This PR adds a badge for the [Filesystem MCP Server](https://glama.ai/mcp/servers/@rawr-ai/mcp-filesystem) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@rawr-ai/mcp-filesystem">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@rawr-ai/mcp-filesystem/badge" alt="Filesystem Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.