### PR TITLE
Allow environment variable paths and document Node usage

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,10 +1,10 @@
 {
   "mcpServers": {
     "filesystem-mcp-directory": {
-      "command": "bun",
+      "command": "node",
       "args": [
-        "/Users/mateicanavra/Documents/.nosync/DEV/mcp-servers/mcp-filesystem/dist/index.js",
-        "/Users/mateicanavra/Documents/.nosync/DEV/mcp-servers/mcp-filesystem/",
+        "$HOME/mcp-servers/mcp-filesystem/dist/index.js",
+        "$HOME/mcp-servers/mcp-filesystem/",
         "--no-follow-symlinks",
         "--readonly"
       ]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Bun-based server implementing Model Context Protocol (MCP) for filesystem operat
    ```bash
    bun install
    ```
-3. **Build the project**
+3. **Build the project** (required for Node runtimes)
    ```bash
    bun run build
    ```
@@ -44,6 +44,35 @@ Bun-based server implementing Model Context Protocol (MCP) for filesystem operat
    ```bash
    bun test
    ```
+
+## Running the server
+
+This repository uses Bun for development, but the compiled JavaScript can be run with **Node**, which is the default runtime for most MCP clients.
+
+- **Node (default)**
+  ```json
+  {
+    "command": "node",
+    "args": ["/path/to/mcp-filesystem/dist/index.js", "$HOME/allowed-directory"]
+  }
+  ```
+
+- **Bun / Bunx (no build step)**
+  ```json
+  {
+    "command": "bun",
+    "args": ["/path/to/mcp-filesystem/index.ts", "$HOME/allowed-directory"]
+  }
+  ```
+  or
+  ```json
+  {
+    "command": "bunx",
+    "args": ["@modelcontextprotocol/server-filesystem", "$HOME/allowed-directory"]
+  }
+  ```
+
+Paths may include environment variables like `$HOME` or `%USERPROFILE%` to reference user-specific locations.
 
 ## API
 
@@ -271,10 +300,10 @@ In `.cursor/mcp.json`:
 {
   "mcpServers": {
     "my-filesystem": {
-      "command": "bun",
+      "command": "node",
       "args": [
         "/path/to/mcp-filesystem/dist/index.js",
-        "~/path/to/allowed/directory",
+        "$HOME/path/to/allowed/directory",
         "--full-access"
       ]
     }
@@ -295,7 +324,7 @@ For Claude Desktop with Docker:
         "run",
         "-i",
         "--rm",
-        "--mount", "type=bind,src=/Users/username/Desktop,dst=/projects/Desktop",
+        "--mount", "type=bind,src=$HOME/Desktop,dst=/projects/Desktop",
         "--mount", "type=bind,src=/path/to/other/allowed/dir,dst=/projects/other/allowed/dir,ro",
         "--mount", "type=bind,src=/path/to/file.txt,dst=/projects/path/to/file.txt",
         "mcp/filesystem",
@@ -320,7 +349,7 @@ For either Claude Desktop or Cursor with Bunx:
       "args": [
           "@modelcontextprotocol/server-filesystem",
         "--full-access",                // For full read/write access
-        "/Users/username/Desktop",
+        "$HOME/Desktop",
         "/path/to/other/allowed/dir"
       ]
     }
@@ -335,7 +364,7 @@ You can configure the server with various permission combinations:
 ```json
 "args": [
   "/path/to/mcp-filesystem/dist/index.js",
-  "~/path/to/allowed/directory",
+  "$HOME/path/to/allowed/directory",
   "--readonly"                         // Read-only mode
 ]
 ```
@@ -343,7 +372,7 @@ You can configure the server with various permission combinations:
 ```json
 "args": [
   "/path/to/mcp-filesystem/dist/index.js",
-  "~/path/to/allowed/directory",
+  "$HOME/path/to/allowed/directory",
   "--full-access",                    // Full read/write access
   "--no-follow-symlinks"              // Don't follow symlinks
 ]
@@ -352,7 +381,7 @@ You can configure the server with various permission combinations:
 ```json
 "args": [
   "/path/to/mcp-filesystem/dist/index.js",
-  "~/path/to/allowed/directory",
+  "$HOME/path/to/allowed/directory",
   "--allow-create",                   // Selective permissions
   "--allow-edit"                      // Only allow creation and editing
 ]
@@ -367,8 +396,8 @@ When specifying multiple directories, permission flags apply **globally** to all
 ```json
 "args": [
   "/path/to/mcp-filesystem/dist/index.js",
-  "~/first/directory",                // Both directories have the same
-  "~/second/directory",               // permission settings (read-only)
+  "$HOME/first/directory",                // Both directories have the same
+  "$HOME/second/directory",               // permission settings (read-only)
   "--readonly"
 ]
 ```
@@ -379,18 +408,18 @@ If you need different permission levels for different directories, create multip
 {
     "mcpServers": {
       "readonly-filesystem": {
-        "command": "bun",
+        "command": "node",
       "args": [
         "/path/to/mcp-filesystem/dist/index.js",
-        "~/sensitive/directory",
+        "$HOME/sensitive/directory",
         "--readonly"
       ]
     },
       "writeable-filesystem": {
-        "command": "bun",
+        "command": "node",
       "args": [
         "/path/to/mcp-filesystem/dist/index.js",
-        "~/sandbox/directory",
+        "$HOME/sandbox/directory",
         "--full-access"
       ]
     }

--- a/examples/mcp_http.json
+++ b/examples/mcp_http.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "filesystem-http": {
-      "command": "bun",
-      "args": ["dist/index.js", "~/allowed/path", "--http", "--port", "8080"]
+      "command": "node",
+      "args": ["dist/index.js", "$HOME/allowed/path", "--http", "--port", "8080"]
     }
   }
 }

--- a/examples/mcp_stdio.json
+++ b/examples/mcp_stdio.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "filesystem-stdio": {
-      "command": "bun",
-      "args": ["dist/index.js", "~/allowed/path"]
+      "command": "node",
+      "args": ["dist/index.js", "$HOME/allowed/path"]
     }
   }
 }

--- a/src/config/permissions.ts
+++ b/src/config/permissions.ts
@@ -1,3 +1,6 @@
+import path from 'path';
+import { expandHome, normalizePath } from '../utils/path-utils.js';
+
 export interface Permissions {
   create: boolean;
   edit: boolean;
@@ -56,6 +59,8 @@ export function parseCommandLineArgs(args: string[]): ServerConfig {
     readonlyFlag,
     noFollowSymlinks,
     permissions,
-    allowedDirectories: cleanArgs
+    allowedDirectories: cleanArgs.map(dir =>
+      normalizePath(path.resolve(expandHome(dir)))
+    )
   };
-} 
+}

--- a/src/utils/path-utils.ts
+++ b/src/utils/path-utils.ts
@@ -9,10 +9,19 @@ export function normalizePath(p: string): string {
 }
 
 export function expandHome(filepath: string): string {
-  if (filepath.startsWith('~/') || filepath === '~') {
-    return path.join(os.homedir(), filepath.slice(1));
+  // Expand $VAR and %VAR% environment variables
+  let expanded = filepath.replace(/\$([A-Za-z_][A-Za-z0-9_]*)|%([A-Za-z_][A-Za-z0-9_]*)%/g, (match, unixVar, winVar) => {
+    const envVar = unixVar || winVar;
+    const value = process.env[envVar];
+    return value !== undefined ? value : match;
+  });
+
+  // Expand ~ to home directory
+  if (expanded.startsWith('~/') || expanded === '~') {
+    expanded = path.join(os.homedir(), expanded.slice(1));
   }
-  return filepath;
+
+  return expanded;
 }
 export type ValidatePathOptions = ReadonlyDeep<{
   checkParentExists?: boolean;

--- a/test/utils/pathUtils.test.ts
+++ b/test/utils/pathUtils.test.ts
@@ -1,0 +1,19 @@
+import os from 'os';
+import path from 'path';
+import { test, expect } from 'bun:test';
+import { expandHome } from '../../src/utils/path-utils.js';
+
+test('expands tilde to home directory', () => {
+  const result = expandHome('~/example');
+  expect(result).toBe(path.join(os.homedir(), 'example'));
+});
+
+test('expands $VAR environment variables', () => {
+  process.env.TEST_VAR = '/tmp/test';
+  expect(expandHome('$TEST_VAR/file.txt')).toBe('/tmp/test/file.txt');
+});
+
+test('expands %VAR% environment variables', () => {
+  process.env.TEST_VAR = '/tmp/test';
+  expect(expandHome('%TEST_VAR%/file.txt')).toBe('/tmp/test/file.txt');
+});


### PR DESCRIPTION
## Summary
- allow `$HOME` and other environment variables in allowed directory paths
- document Node vs Bun usage and update examples to use `$HOME`
- sanitize repo config to remove personal filesystem paths

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6893a3d2b3e08322ac4f6a95500d65eb